### PR TITLE
Remove msg debugging

### DIFF
--- a/block_auto_apply_runs.rego
+++ b/block_auto_apply_runs.rego
@@ -2,10 +2,11 @@ package terraform.tfc.block_auto_apply_runs
 
 import input.run as run
 
-deny[msg] {
+# deny[msg] {
+deny {
     run.workspace.auto_apply != false
-    msg := sprintf(
-        "HCP Terraform workspace %s has been configured to automatically provision Terraform infrastructure. Change the workspace Apply Method settings to 'Manual Apply'",
-        [run.workspace.name],
-    )
+    # msg := sprintf(
+    #     "HCP Terraform workspace %s has been configured to automatically provision Terraform infrastructure. Change the workspace Apply Method settings to 'Manual Apply'",
+    #     [run.workspace.name],
+    # )
 }

--- a/input.json
+++ b/input.json
@@ -1,0 +1,1 @@
+{"run": {"workspace": {"auto_apply": true}}}


### PR DESCRIPTION
In this PR the policy and tests do work (with "opa test") when we disable the "msg" part (can be confirmed also by running:

`# opa eval --v0-compatible -i input.json -d block_auto_apply_runs.rego "data.terraform.tfc.block_auto_apply_runs.deny"
`

Copilot summary:

This pull request includes changes to the `block_auto_apply_runs.rego` file and the addition of a new `input.json` file. The changes primarily focus on modifying the logic for denying auto-apply runs in Terraform workspaces.

Changes to `block_auto_apply_runs.rego`:

* Commented out the `deny[msg]` rule and replaced it with a simplified `deny` rule without a message.

Changes to `input.json`:

* Added a new JSON input file with a sample configuration where the `auto_apply` flag is set to `true`.